### PR TITLE
adding jd f4mini board type

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -46,4 +46,5 @@ AP_HW_SPEEDYBEEF4                     134
 AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
+AP_HW_HELIOSPRING                     138
 AP_HW_F4BY                             20 # value due to previous release by vendor

--- a/board_types.txt
+++ b/board_types.txt
@@ -47,4 +47,5 @@ AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
 AP_HW_HELIOSPRING                     138
+AP_HW_JDF4MINI                        139
 AP_HW_F4BY                             20 # value due to previous release by vendor


### PR DESCRIPTION
Adding/reserving ID for our f405 based board