### PR TITLE
Add target Pixhawk4 and Pixhawk4_mini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,9 @@ TARGETS	= \
 	px4iov3_bl \
 	tapv1_bl \
 	cube_f4_bl \
-	avx_v1_bl
+	avx_v1_bl \
+	pixhawk4_bl \
+	pixhawk4_mini_bl
 
 all:	$(TARGETS) sizes
 
@@ -136,6 +138,12 @@ cube_f7_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 avx_v1_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
 	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=AV_X_V1 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
 
+pixhawk4_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=PIXHAWK4 LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+
+pixhawk4_mini_bl:$(MAKEFILE_LIST) $(LIBOPENCM3)
+	${MAKE} ${MKFLAGS} -f  Makefile.f7 TARGET_HW=PIXHAWK4_MINI LINKER_FILE=stm32f7.ld TARGET_FILE_NAME=$@
+	
 # Default bootloader delay is *very* short, just long enough to catch
 # the board for recovery but not so long as to make restarting after a
 # brownout problematic.

--- a/board_types.txt
+++ b/board_types.txt
@@ -46,4 +46,5 @@ AP_HW_SPEEDYBEEF4                     134
 AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
+AP_HW_HELIOSPRING                     138
 AP_HW_F4BY                             20 # value due to previous release by vendor

--- a/board_types.txt
+++ b/board_types.txt
@@ -7,6 +7,8 @@ TARGET_HW_PX4_FMU_V3                    9 # same as FMU_V2
 TARGET_HW_PX4_FMU_V4                   11
 TARGET_HW_PX4_FMU_V4_PRO               13
 TARGET_HW_PX4_FMU_V5                   50
+TARGET_HW_PIXHAWK4                     50 # same as FMU_V5
+TARGET_HW_PIXHAWK4_MINI                51
 TARGET_HW_MINDPX_V2                    88
 TARGET_HW_PX4_FLOW_V1                   6
 TARGET_HW_PX4_DISCOVERY_V1             99

--- a/hw_config.h
+++ b/hw_config.h
@@ -385,6 +385,88 @@
 */
 
 /****************************************************************************
+ * TARGET_HW_PIXHAWK4
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_PIXHAWK4)
+
+# define APP_LOAD_ADDRESS               0x08008000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "Pixhawk4 BL"
+# define USBPRODUCTID                   0x0047
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     50
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       16
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO7 // BLUE
+# define BOARD_PIN_LED_BOOTLOADER       GPIO6 // GREEN
+# define BOARD_PORT_LEDS                GPIOC
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOCEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_GPIODEN
+# define SERIAL_BREAK_DETECT_DISABLED   1
+# define USBMFGSTRING "Holybro"
+
+/****************************************************************************
+ * TARGET_HW_PIXHAWK4_MINI
+ ****************************************************************************/
+
+#elif  defined(TARGET_HW_PIXHAWK4_MINI)
+
+# define APP_LOAD_ADDRESS               0x08008000
+# define BOOTLOADER_DELAY               5000
+# define INTERFACE_USB                  1
+# define INTERFACE_USART                1
+# define USBDEVICESTRING                "Pixhawk4 Mini BL"
+# define USBPRODUCTID                   0x0049
+# define BOOT_DELAY_ADDRESS             0x000001a0
+
+# define BOARD_TYPE                     51
+# define _FLASH_KBYTES                  (*(uint16_t *)0x1ff0f442)
+# define BOARD_FLASH_SECTORS            ((_FLASH_KBYTES == 0x400) ? 7 : 11)
+# define BOARD_FLASH_SIZE               (_FLASH_KBYTES * 1024)
+
+# define OSC_FREQ                       16
+
+# define BOARD_PIN_LED_ACTIVITY         GPIO7 // BLUE
+# define BOARD_PIN_LED_BOOTLOADER       GPIO6 // GREEN
+# define BOARD_PORT_LEDS                GPIOC
+# define BOARD_CLOCK_LEDS               RCC_AHB1ENR_GPIOCEN
+# define BOARD_LED_ON                   gpio_clear
+# define BOARD_LED_OFF                  gpio_set
+
+# define BOARD_USART  					USART2
+# define BOARD_USART_CLOCK_REGISTER 	RCC_APB1ENR
+# define BOARD_USART_CLOCK_BIT      	RCC_APB1ENR_USART2EN
+
+# define BOARD_PORT_USART   			GPIOD
+# define BOARD_PORT_USART_AF 			GPIO_AF7
+# define BOARD_PIN_TX     				GPIO5
+# define BOARD_PIN_RX		     		GPIO6
+# define BOARD_USART_PIN_CLOCK_REGISTER RCC_AHB1ENR
+# define BOARD_USART_PIN_CLOCK_BIT  	RCC_AHB1ENR_GPIODEN
+# define SERIAL_BREAK_DETECT_DISABLED   1
+# define USBMFGSTRING "Holybro"
+
+/****************************************************************************
  * TARGET_HW_MINDPX_V2
  ****************************************************************************/
 


### PR DESCRIPTION
Pixhawk4 base on FMUV5. It have some differences with PX4_PIO_V2. The Sbus signal and Dsm signal are tied together on Pixhawk4, but thay are separated on PX4_PIO_V2. So we need a new USBPRODUCTID and USBDEVICESTRING to distinguishing Pixhawk4 from FMUV5. Also, the USBPRODUCTID(0x0032) of FMUV5 has been defined by MindPX in MissionPlanner's drivers. You can see the detail in  ..\Mission Planner\Drivers\mindpx.inf. When the users plug in a Pixhawk4 or FMUV5, it is recognized as "MindPx" device. Although this does not affect the connection of FC, but peoples are confused about this.

Pixhawk4_mini  doesn't have IO MCU, and the PCB board is quite  different from pixhawk4. It should have his own bootloader. 