### PR TITLE
Bootloader: update board_types.txt

### DIFF
--- a/board_types.txt
+++ b/board_types.txt
@@ -46,4 +46,5 @@ AP_HW_SPEEDYBEEF4                     134
 AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
+AP_HW_HELIOSPRING                     138
 AP_HW_F4BY                             20 # value due to previous release by vendor

--- a/board_types.txt
+++ b/board_types.txt
@@ -7,6 +7,9 @@ TARGET_HW_PX4_FMU_V3                    9 # same as FMU_V2
 TARGET_HW_PX4_FMU_V4                   11
 TARGET_HW_PX4_FMU_V4_PRO               13
 TARGET_HW_PX4_FMU_V5                   50
+TARGET_HW_PX4_FMU_V5X                  51
+TARGET_HW_PX4_FMU_V6                   52
+TARGET_HW_PX4_FMU_V6X                  53
 TARGET_HW_MINDPX_V2                    88
 TARGET_HW_PX4_FLOW_V1                   6
 TARGET_HW_PX4_DISCOVERY_V1             99
@@ -21,6 +24,8 @@ TARGET_HW_AUAV_X2V1                    33
 TARGET_HW_AEROFC_V1                    65
 TARGET_HW_CUBE_F4                       9
 TARGET_HW_AV_V1                        29
+#TARGET_HW_KAKUTEF7                    123 #same as AP_HW_KAKUTEF7
+TARGET_HW_SMARTAP_PRO                  32
 
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
@@ -32,12 +37,13 @@ EXT_HW_RADIOLINK_MINI_PIX               3
 AP_HW_CUBE_ORANGE                     120
 AP_HW_OMNIBUSF7V2                     121
 AP_HW_KAKUTEF4                        122
-AP_HW_KAKUTEF7                        123
+AP_HW_KAKUTEF7                        123 # pulled upstream as TARGET_HW_KAKUTEF7
 AP_HW_REVOLUTION                      124
 AP_HW_MATEKF405                       125
 AP_HW_NUCLEOF767ZI                    126
 AP_HW_MATEKF405_WING                  127
 AP_HW_AIRBOTF4                        128
+AP_HW_CUBE_YELLOW                     129
 AP_HW_SPARKYV2                        130
 AP_HW_OMNIBUSF4PRO                    131
 AP_HW_ANYFCF7                         132
@@ -49,4 +55,14 @@ AP_HW_OMNIBUSF4V6                     137
 AP_HW_HELIOSPRING                     138
 AP_HW_JDMINIF405                      139
 AP_HW_JDF7                            140
+AP_HW_MRO_CONTROL_ZERO                141
+AP_HW_MRO_CONTROL_ZERO_OEM            142
+AP_HW_MATEKF765_WING                  143
 AP_HW_F4BY                             20 # value due to previous release by vendor
+AP_HW_VRBRAIN_V51                    1151
+AP_HW_VRBRAIN_V52                    1152
+AP_HW_VRBRAIN_V54                    1154
+AP_HW_VRCORE_V10                     1910
+AP_HW_VRUBRAIN_V51                   1351
+
+

--- a/board_types.txt
+++ b/board_types.txt
@@ -47,4 +47,6 @@ AP_HW_F35LIGHTNING                    135
 AP_HW_MRO_X2V1_777                    136
 AP_HW_OMNIBUSF4V6                     137
 AP_HW_HELIOSPRING                     138
+AP_HW_JDMINIF405                      139
+AP_HW_JDF7                            140
 AP_HW_F4BY                             20 # value due to previous release by vendor


### PR DESCRIPTION
Sync between PX4 and ArduPilot.  Add missing ID's from hwdef_bl.dat files.
Cube Yellow and Pixhawk 6 board definitions need follow on correction.